### PR TITLE
Lambda configuration through serverless

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -92,4 +92,9 @@ functions:
           input:
             backup_type: ebs
             action: clean_backups
-
+    environment:
+      shelvery_keep_daily_backups: ${env:shelvery_keep_daily_backups,14}
+      shelvery_keep_weekly_backups: ${env:shelvery_keep_weekly_backups,8}
+      shelvery_keep_monthly_backups: ${env:shelvery_keep_monthly_backups,12}
+      shelvery_keep_yearly_backups: ${env:shelvery_keep_yearly_backups,10}
+      shelvery_dr_regions: ${env:shelvery_dr_regions,''}


### PR DESCRIPTION
When doing `sls deploy -r $region --stage $stage` it should be allowed to configure deployed lambda function. E.g. deploying to primary and dr region:

```
$ sls deploy -r us-east-1
$ export shelvery_keep_daily_backups=1
$ export shelvery_keep_monthly_backups=1
$ export shelvery_keep_weekly_backups=1
$ sls deploy -r us-east-2
```