### PR TITLE
Support for RDS Cluster snapshots

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,2 +1,3 @@
 v0.1.0, 6/11/2017 -- Initial release.
 v0.2.0, 14/11/2017 -- Control behaviour via resource tags. Multiple levels of configuration. RDS Cleanup.
+v0.3.0, 20/12/2017 -- RDS Cluster backups added

--- a/serverless.yml
+++ b/serverless.yml
@@ -5,12 +5,14 @@ provider:
   name: aws
   runtime: python3.6
   iamRoleStatements:
+    # read only ec2, rds
     - Effect: Allow
       Action:
         - 'ec2:Describe*'
         - 'rds:Describe*'
         - 'rds:ListTagsForResource'
       Resource: '*'
+    # manage ebs snapshots and tags
     - Effect: Allow
       Action:
         - ec2:CreateSnapshot
@@ -22,12 +24,17 @@ provider:
         - ec2:DeleteTags
         - ec2:CopySnapshot
       Resource: '*'
+    # manage rds snaphosts and tags
     - Effect: Allow
       Action:
         - rds:ModifyDBSnapshotAttribute
+        - rds:MOdifyDBClusterSnapshotAttribute
         - rds:CopyDBSnapshot
+        - rds:CopyDBClusterSnapshot
         - rds:DeleteDBSnapshot
+        - rds:DeleteDBClusterSnapshot
         - rds:CreateDBSnapshot
+        - rds:CreateDBClusterSnapshot
         - rds:AddTagsToResource
         - rds:RemoveTagsFromResource
       Resource: '*'
@@ -78,6 +85,13 @@ functions:
           input:
             backup_type: rds
             action: create_backups
+      # create rds cluster
+      - schedule:
+          rate: 'cron(0 1 ? * * *)'
+          enabled: true
+          input:
+            backup_type: rds_cluster
+            action: create_backups
       # clean ebs
       - schedule:
           rate: 'cron(0 2 ? * * *)'
@@ -90,7 +104,14 @@ functions:
           rate: 'cron(0 2 ? * * *)'
           enabled: true
           input:
-            backup_type: ebs
+            backup_type: rds
+            action: clean_backups
+      # clean rds cluster
+      - schedule:
+          rate: 'cron(0 2 ? * * *)'
+          enabled: true
+          input:
+            backup_type: rds_cluster
             action: clean_backups
     environment:
       shelvery_keep_daily_backups: ${env:shelvery_keep_daily_backups,'14'}
@@ -98,3 +119,5 @@ functions:
       shelvery_keep_monthly_backups: ${env:shelvery_keep_monthly_backups,'12'}
       shelvery_keep_yearly_backups: ${env:shelvery_keep_yearly_backups,'10'}
       shelvery_dr_regions: ${env:shelvery_dr_regions,''}
+      shelvery_share_aws_account_ids: ${env:shelvery_share_aws_account_ids,''}
+      shelvery_rds_backup_mode: ${env:shelvery_rds_backup_mode,'RDS_COPY_AUTOMATED_SNAPSHOT'}

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup
 
-setup(name='shelvery', version='0.2.0', author='Base2Services R&D',
+setup(name='shelvery', version='0.3.0', author='Base2Services R&D',
       author_email='itsupport@base2services.com',
       url='http://github.com/base2Services/shelvery',
       classifiers=[

--- a/shelvery/engine.py
+++ b/shelvery/engine.py
@@ -17,16 +17,16 @@ LAMBDA_WAIT_ITERATION = 'lambda_wait_iteration'
 
 class ShelveryEngine:
     """Base class for all backup processing, contains logic"""
-    
+
     __metaclass__ = abc.ABCMeta
-    
+
     DEFAULT_KEEP_DAILY = 14
     DEFAULT_KEEP_WEEKLY = 8
     DEFAULT_KEEP_MONTHLY = 12
     DEFAULT_KEEP_YEARLY = 10
-    
+
     BACKUP_RESOURCE_TAG = 'create_backup'
-    
+
     def __init__(self):
         # system logger
         FORMAT = "%(asctime)s %(process)s %(thread)s: %(message)s"
@@ -38,24 +38,24 @@ class ShelveryEngine:
         self.lambda_wait_iteration = 0
         self.lambda_payload = None
         self.lambda_context = None
-    
+
     def set_lambda_environment(self, payload, context):
         self.lambda_payload = payload
         self.lambda_context = context
         self.aws_request_id = context.aws_request_id
         if ('arguments' in payload) and (LAMBDA_WAIT_ITERATION in payload['arguments']):
             self.lambda_wait_iteration = payload['arguments'][LAMBDA_WAIT_ITERATION]
-    
+
     def create_backups(self):
         """Create backups from all collected entities marked for backup by using specific tag"""
-        
+
         # collect resources to be backed up
         resource_type = self.get_resource_type()
         self.logger.info(f"Collecting entities of type {resource_type} tagged with "
                          f"{RuntimeConfig.get_tag_prefix()}:{self.BACKUP_RESOURCE_TAG}")
         resources = self.get_entities_to_backup(f"{RuntimeConfig.get_tag_prefix()}:{self.BACKUP_RESOURCE_TAG}")
         self.logger.info(f"{len(resources)} resources of type {resource_type} collected for backup")
-        
+
         # create and collect backups
         backup_resources = []
         for r in resources:
@@ -65,20 +65,23 @@ class ShelveryEngine:
             )
             self.logger.info(f"Processing {resource_type} with id {r.resource_id}")
             self.logger.info(f"Creating backup {backup_resource.name}")
-            self.backup_resource(backup_resource)
-            self.tag_backup_resource(backup_resource)
-            self.logger.info(f"Created backup of type {resource_type} for entity {backup_resource.entity_id} "
-                             f"with id {backup_resource.backup_id}")
-            backup_resources.append(backup_resource)
-        
+            try:
+                self.backup_resource(backup_resource)
+                self.tag_backup_resource(backup_resource)
+                self.logger.info(f"Created backup of type {resource_type} for entity {backup_resource.entity_id} "
+                                 f"with id {backup_resource.backup_id}")
+                backup_resources.append(backup_resource)
+            except Exception as e:
+                self.logger.error(f"Failed to create backup {backup_resource.name}:{e}")
+
         # create backups and disaster recovery region
         for br in backup_resources:
             self.copy_backup(br, RuntimeConfig.get_dr_regions(br.entity_resource.tags, self))
-        
+
         for aws_account_id in RuntimeConfig.get_share_with_accounts(self):
             for br in backup_resources:
                 self.share_backup(br, aws_account_id)
-    
+
     def clean_backups(self):
         # collect backups
         existing_backups = self.get_existing_backups(RuntimeConfig.get_tag_prefix())
@@ -88,7 +91,7 @@ class ShelveryEngine:
                             Keeping last {RuntimeConfig.get_keep_weekly(None, self)} weekly backups
                             Keeping last {RuntimeConfig.get_keep_monthly(None, self)} monthly backups
                             Keeping last {RuntimeConfig.get_keep_yearly(None, self)} yearly backups""")
-        
+
         # check backups for expire date, delete if necessary
         for backup in existing_backups:
             if backup.is_stale(self):
@@ -98,17 +101,17 @@ class ShelveryEngine:
             else:
                 self.logger.info(f"{backup.retention_type} backup {backup.name} is valid "
                                  f"until {backup.expire_date}, keeping this backup")
-    
+
     def do_wait_backup_available(self, backup_region: str, backup_id: str, timeout_fn=None):
         """Wait for backup to become available. Additionally pass on timeout function
             to be executed if code is running in lambda environment, and remaining execution
             time is lower than threshold of 20 seconds"""
-        
+
         total_wait_time = 0
         retry = 15
         timeout = RuntimeConfig.get_wait_backup_timeout(self)
         self.logger.info(f"Waiting for backup {backup_id} to become available, timing out after {timeout} seconds...")
-        
+
         available = self.is_backup_available(backup_region, backup_id)
         while not available:
             if total_wait_time >= timeout or total_wait_time + retry > timeout:
@@ -118,46 +121,46 @@ class ShelveryEngine:
             time.sleep(retry)
             total_wait_time = total_wait_time + retry
             available = self.is_backup_available(backup_region, backup_id)
-    
+
     def wait_backup_available(self, backup_region: str, backup_id: str, lambda_method: str, lambda_args: Dict) -> bool:
         """Wait for backup to become available. If running in lambda environment, pass lambda method and
             arguments to be executed if lambda functions times out, and return false. Always return true
             in non-lambda mode"""
         has_timed_out = {'value': False}
         engine = self
-        
+
         def call_recursively():
             # check if exceeded allowed number of wait iterations in lambda
             if self.lambda_wait_iteration > RuntimeConfig.get_max_lambda_wait_iterations():
                 raise Exception(f"Reached maximum of {RuntimeConfig.get_max_lambda_wait_iterations()} lambda wait"
                                 f"operations")
-            
+
             lambda_args['lambda_wait_iteration'] = self.lambda_wait_iteration + 1
             ShelveryInvoker().invoke_shelvery_operation(
                 engine,
                 method_name=lambda_method,
                 method_arguments=lambda_args)
             has_timed_out['value'] = True
-        
+
         def panic():
             self.logger.error(f"Failed to wait for backup to become available, exiting...")
             sys.exit(-5)
-        
+
         # if running in lambda environment, call function recursively on timeout
         # otherwise in cli mode, just exit
         timeout_fn = call_recursively if RuntimeConfig.is_lambda_runtime(self) else panic
         self.do_wait_backup_available(backup_region=backup_region, backup_id=backup_id, timeout_fn=timeout_fn)
         return not (has_timed_out['value'] and RuntimeConfig.is_lambda_runtime(self))
-    
+
     def copy_backup(self, backup_resource: BackupResource, target_regions: List[str]):
         """Copy backup to set of regions - this is orchestration method, rather than
             logic implementation"""
         method = 'do_copy_backup'
-        
+
         # tag source backup with dr regions
         backup_resource.tags[f"{RuntimeConfig.get_tag_prefix()}:dr_regions"] = ','.join(target_regions)
         self.tag_backup_resource(backup_resource)
-        
+
         # call lambda recursively for each backup / region pair
         for region in target_regions:
             arguments = {
@@ -166,13 +169,13 @@ class ShelveryEngine:
                 'Region': region
             }
             ShelveryInvoker().invoke_shelvery_operation(self, method, arguments)
-    
+
     def share_backup(self, backup_resource: BackupResource, aws_account_id: str):
         """
         Share backup with other AWS account - this is orchestration method, rather than
         logic implementation, invokes actual implementation or lambda
         """
-        
+
         method = 'do_share_backup'
         arguments = {
             'Region': backup_resource.region,
@@ -180,14 +183,14 @@ class ShelveryEngine:
             'AwsAccountId': aws_account_id
         }
         ShelveryInvoker().invoke_shelvery_operation(self, method, arguments)
-    
+
     def do_copy_backup(self, map_args={}, **kwargs):
         """
         Copy backup to another region, actual implementation
         """
-        
+
         kwargs.update(map_args)
-        
+
         # if backup is not available, exit and rely on recursive lambda call copy backup
         # in non lambda mode this should never happen
         if not self.wait_backup_available(backup_region=kwargs['OriginRegion'],
@@ -195,14 +198,14 @@ class ShelveryEngine:
                                           lambda_method='do_copy_backup',
                                           lambda_args=kwargs):
             return
-        
+
         self.logger.info(f"Do copy backup {kwargs['BackupId']} ({kwargs['OriginRegion']}) to region {kwargs['Region']}")
-        
+
         # copy backup
         src_region = kwargs['OriginRegion']
         dst_region = kwargs['Region']
         regional_backup_id = self.copy_backup_to_region(kwargs['BackupId'], dst_region)
-        
+
         # create tags on backup copy
         original_backup_id = kwargs['BackupId']
         original_backup = self.get_backup_resource(src_region, original_backup_id)
@@ -210,32 +213,32 @@ class ShelveryEngine:
         resource_copy.backup_id = regional_backup_id
         resource_copy.region = kwargs['Region']
         resource_copy.tags = original_backup.tags.copy()
-        
+
         # add metadata to dr copy and original
         dr_copies_tag_key = f"{RuntimeConfig.get_tag_prefix()}:dr_copies"
         resource_copy.tags[f"{RuntimeConfig.get_tag_prefix()}:region"] = dst_region
         resource_copy.tags[f"{RuntimeConfig.get_tag_prefix()}:dr_copy"] = 'true'
         resource_copy.tags[f"{RuntimeConfig.get_tag_prefix()}:dr_source_backup"] = f"{src_region}:{original_backup_id}"
-        
+
         if dr_copies_tag_key not in original_backup.tags:
             original_backup.tags[dr_copies_tag_key] = ''
         original_backup.tags[dr_copies_tag_key] = original_backup.tags[
                                                       dr_copies_tag_key] + f"{dst_region}:{regional_backup_id} "
-        
+
         self.tag_backup_resource(resource_copy)
         self.tag_backup_resource(original_backup)
-        
+
         # shared backup copy with same accounts
         for shared_account_id in RuntimeConfig.get_share_with_accounts(self):
             backup_resource = BackupResource(None, None, True)
             backup_resource.backup_id = regional_backup_id
             backup_resource.region = kwargs['Region']
             self.share_backup(backup_resource, shared_account_id)
-    
+
     def do_share_backup(self, map_args={}, **kwargs):
         """Share backup with other AWS account, actual implementation"""
         kwargs.update(map_args)
-        
+
         # if backup is not available, exit and rely on recursive lambda call do share backup
         # in non lambda mode this should never happen
         if not self.wait_backup_available(backup_region=kwargs['Region'],
@@ -243,77 +246,77 @@ class ShelveryEngine:
                                           lambda_method='do_share_backup',
                                           lambda_args=kwargs):
             return
-        
+
         self.logger.info(f"Do share backup {kwargs['BackupId']} ({kwargs['Region']}) with {kwargs['AwsAccountId']}")
         self.share_backup_with_account(kwargs['Region'], kwargs['BackupId'], kwargs['AwsAccountId'])
-    
+
     ####
     # Abstract methods, for engine implementations to implement
     ####
-    
+
     @abstractmethod
     def get_engine_type(self) -> str:
         """
         Return engine type, valid string to be passed to ShelveryFactory.get_shelvery_instance method
         """
-    
+
     @abstractclassmethod
     def get_resource_type(self) -> str:
         """
         Returns entity type that's about to be backed up
         """
-    
+
     @abstractmethod
     def delete_backup(self, backup_resource: BackupResource):
         """
         Remove given backup from system
         """
-    
+
     @abstractmethod
     def get_existing_backups(self, backup_tag_prefix: str) -> List[BackupResource]:
         """
         Collect existing backups on system of given type, marked with given tag
         """
-    
+
     @abstractmethod
     def get_entities_to_backup(self, tag_name: str) -> List[EntityResource]:
         """
         Returns list of objects with 'date_created', 'id' and 'tags' properties
         """
         return []
-    
+
     @abstractmethod
     def backup_resource(self, backup_resource: BackupResource):
         """
         Returns list of objects with 'date_created', 'id' and 'tags' properties
         """
         return
-    
+
     @abstractmethod
     def tag_backup_resource(self, backup_resource: BackupResource):
         """
         Create backup resource tags
         """
-    
+
     @abstractmethod
     def copy_backup_to_region(self, backup_id: str, region: str) -> str:
         """
         Copy backup to another region
         """
-    
+
     @abstractmethod
     def is_backup_available(self, backup_region: str, backup_id: str) -> bool:
         """
         Determine whether backup has completed and is available to be copied
         to other regions and shared with other ebs accounts
         """
-    
+
     @abstractmethod
     def share_backup_with_account(self, backup_region: str, backup_id: str, aws_account_id: str):
         """
         Share backup with another AWS Account
         """
-    
+
     @abstractmethod
     def get_backup_resource(self, backup_region: str, backup_id: str) -> BackupResource:
         """

--- a/shelvery/factory.py
+++ b/shelvery/factory.py
@@ -1,16 +1,20 @@
 from shelvery.ebs_backup import ShelveryEBSBackup
 from shelvery.engine import ShelveryEngine
 from shelvery.rds_backup import  ShelveryRDSBackup
+from shelvery.rds_cluster_backup import ShelveryRDSClusterBackup
 
 class ShelveryFactory:
-    
+
     @classmethod
     def get_shelvery_instance(cls, type: str) -> ShelveryEngine:
         if type == 'ebs':
             return ShelveryEBSBackup()
-        
+
         if type == 'rds':
             return ShelveryRDSBackup()
-        
+
+        if type == 'rds_cluster':
+            return ShelveryRDSClusterBackup()
+
         if type == 'ami':
             raise Exception("AMIs not supported yet")

--- a/shelvery/rds_cluster_backup.py
+++ b/shelvery/rds_cluster_backup.py
@@ -9,18 +9,19 @@ from typing import Dict, List
 from botocore.errorfactory import ClientError
 
 
-class ShelveryRDSBackup(ShelveryEngine):
+class ShelveryRDSClusterBackup(ShelveryEngine):
+
     def is_backup_available(self, backup_region: str, backup_id: str) -> bool:
         rds_client = boto3.client('rds', region_name=backup_region)
-        snapshots = rds_client.describe_db_snapshots(DBSnapshotIdentifier=backup_id)
-        return snapshots['DBSnapshots'][0]['Status'] == 'available'
+        snapshots = rds_client.describe_db_cluster_snapshots(DBClusterSnapshotIdentifier=backup_id)
+        return snapshots['DBClusterSnapshots'][0]['Status'] == 'available'
 
     def get_resource_type(self) -> str:
-        return 'RDS Instance'
+        return 'RDS Cluster'
 
     def backup_resource(self, backup_resource: BackupResource) -> BackupResource:
         if RuntimeConfig.get_rds_mode(backup_resource.entity_resource.tags, self) == RuntimeConfig.RDS_CREATE_SNAPSHOT:
-            return self.backup_from_instance(backup_resource)
+            return self.backup_from_cluster(backup_resource)
         if RuntimeConfig.get_rds_mode(backup_resource.entity_resource.tags, self) == RuntimeConfig.RDS_COPY_AUTOMATED_SNAPSHOT:
             return self.backup_from_latest_automated(backup_resource)
 
@@ -30,46 +31,47 @@ class ShelveryRDSBackup(ShelveryEngine):
 
     def backup_from_latest_automated(self, backup_resource: BackupResource):
         rds_client = boto3.client('rds')
-        auto_snapshots = rds_client.describe_db_snapshots(
-            DBInstanceIdentifier=backup_resource.entity_id,
+        auto_snapshots = rds_client.describe_db_cluster_snapshots(
+            DBClusterIdentifier=backup_resource.entity_id,
             SnapshotType='automated',
             # API always returns in date descending order, and we only need last one
             MaxRecords=20
         )
-        auto_snapshots = sorted(auto_snapshots['DBSnapshots'], key=lambda k: k['SnapshotCreateTime'], reverse=True)
+        auto_snapshots = sorted(auto_snapshots['DBClusterSnapshots'], key=lambda k: k['SnapshotCreateTime'], reverse=True)
 
         # TODO handle case when there are no latest automated backups
-        automated_snapshot_id = auto_snapshots[0]['DBSnapshotIdentifier']
-        rds_client.copy_db_snapshot(
-            SourceDBSnapshotIdentifier=automated_snapshot_id,
-            TargetDBSnapshotIdentifier=backup_resource.name,
+        automated_snapshot_id = auto_snapshots[0]['DBClusterSnapshotIdentifier']
+        rds_client.copy_db_cluster_snapshot(
+            SourceDBClusterSnapshotIdentifier=automated_snapshot_id,
+            TargetDBClusterSnapshotIdentifier=backup_resource.name,
             CopyTags=False
         )
         backup_resource.backup_id = backup_resource.name
         return backup_resource
 
-    def backup_from_instance(self, backup_resource):
+    def backup_from_cluster(self, backup_resource):
         rds_client = boto3.client('rds')
-        rds_client.create_db_snapshot(
-            DBSnapshotIdentifier=backup_resource.name,
-            DBInstanceIdentifier=backup_resource.entity_id
+        rds_client.create_db_cluster_snapshot(
+            DBClusterSnapshotIdentifier=backup_resource.name,
+            DBClusterIdentifier=backup_resource.entity_id
         )
         backup_resource.backup_id = backup_resource.name
         return backup_resource
 
     def delete_backup(self, backup_resource: BackupResource):
         rds_client = boto3.client('rds')
-        rds_client.delete_db_snapshot(
-            DBSnapshotIdentifier=backup_resource.backup_id
+        rds_client.delete_db_cluster_snapshot(
+            DBClusterSnapshotIdentifier=backup_resource.backup_id
         )
 
     def tag_backup_resource(self, backup_resource: BackupResource):
         regional_rds_client = boto3.client('rds', region_name=backup_resource.region)
-        snapshots = regional_rds_client.describe_db_snapshots(DBSnapshotIdentifier=backup_resource.backup_id)
-        snapshot_arn = snapshots['DBSnapshots'][0]['DBSnapshotArn']
+        snapshots = regional_rds_client.describe_db_cluster_snapshots(DBClusterSnapshotIdentifier=backup_resource.backup_id)
+        snapshot_arn = snapshots['DBClusterSnapshots'][0]['DBClusterSnapshotArn']
+        tags = list(map(lambda k: {'Key': k, 'Value': backup_resource.tags[k].replace(',', ' ')}, backup_resource.tags))
         regional_rds_client.add_tags_to_resource(
             ResourceName=snapshot_arn,
-            Tags=list(map(lambda k: {'Key': k, 'Value': backup_resource.tags[k].replace(',', ' ')}, backup_resource.tags))
+            Tags=tags
         )
 
     def get_existing_backups(self, backup_tag_prefix: str) -> List[BackupResource]:
@@ -85,8 +87,8 @@ class ShelveryRDSBackup(ShelveryEngine):
 
     def share_backup_with_account(self, backup_region: str, backup_id: str, aws_account_id: str):
         rds_client = boto3.client('rds', region_name=backup_region)
-        rds_client.modify_db_snapshot_attribute(
-            DBSnapshotIdentifier=backup_id,
+        rds_client.modify_db_cluster_snapshot_attribute(
+            DBClusterSnapshotIdentifier=backup_id,
             AttributeName='restore',
             ValuesToAdd=[aws_account_id]
         )
@@ -95,11 +97,11 @@ class ShelveryRDSBackup(ShelveryEngine):
         local_region = boto3.session.Session().region_name
         client_local = boto3.client('rds')
         rds_client = boto3.client('rds', region_name=region)
-        snapshots = client_local.describe_db_snapshots(DBSnapshotIdentifier=backup_id)
-        snapshot = snapshots['DBSnapshots'][0]
-        rds_client.copy_db_snapshot(
-            SourceDBSnapshotIdentifier=snapshot['DBSnapshotArn'],
-            TargetDBSnapshotIdentifier=backup_id,
+        snapshots = client_local.describe_db_cluster_snapshots(DBClusterSnapshotIdentifier=backup_id)
+        snapshot = snapshots['DBClusterSnapshots'][0]
+        rds_client.copy_db_cluster_snapshot(
+            SourceDBClusterSnapshotIdentifier=snapshot['DBClusterSnapshotArn'],
+            TargetDBClusterSnapshotIdentifier=backup_id,
             SourceRegion=local_region,
             # tags are created explicitly
             CopyTags=False
@@ -108,14 +110,14 @@ class ShelveryRDSBackup(ShelveryEngine):
 
     def get_backup_resource(self, backup_region: str, backup_id: str) -> BackupResource:
         rds_client = boto3.client('rds', region_name=backup_region)
-        snapshots = rds_client.describe_db_snapshots(DBSnapshotIdentifier=backup_id)
-        snapshot = snapshots['DBSnapshots'][0]
-        tags = rds_client.list_tags_for_resource(ResourceName=snapshot['DBSnapshotArn'])['TagList']
+        snapshots = rds_client.describe_db_cluster_snapshots(DBClusterSnapshotIdentifier=backup_id)
+        snapshot = snapshots['DBClusterSnapshots'][0]
+        tags = rds_client.list_tags_for_resource(ResourceName=snapshot['DBClusterSnapshotArn'])['TagList']
         d_tags = dict(map(lambda t: (t['Key'], t['Value']), tags))
         return BackupResource.construct(d_tags['shelvery:tag_name'], backup_id, d_tags)
 
     def get_engine_type(self) -> str:
-        return 'rds'
+        return 'rds_cluster'
 
     def get_entities_to_backup(self, tag_name: str) -> List[EntityResource]:
         # region and api client
@@ -123,50 +125,45 @@ class ShelveryRDSBackup(ShelveryEngine):
         rds_client = boto3.client('rds')
 
         # list of models returned from api
-        db_entities = []
+        db_cluster_entities = []
 
-        db_instances = self.get_all_instances(rds_client)
+        db_clusters = self.get_all_clusters(rds_client)
 
         # collect tags in check if instance tagged with marker tag
 
-        for instance in db_instances:
-            tags = rds_client.list_tags_for_resource(ResourceName=instance['DBInstanceArn'])['TagList']
+        for instance in db_clusters:
+            tags = rds_client.list_tags_for_resource(ResourceName=instance['DBClusterArn'])['TagList']
 
             # convert api response to dictionary
             d_tags = dict(map(lambda t: (t['Key'], t['Value']), tags))
 
-            if 'DBClusterIdentifier' in instance:
-                self.logger.info(f"Skipping RDS Instance {instance['DBInstanceIdentifier']} skipped as it is part"
-                                 f" of cluster {instance['DBClusterIdentifier']}")
-                continue
-
             # check if marker tag is present
             if tag_name in d_tags:
-                resource = EntityResource(instance['DBInstanceIdentifier'],
+                resource = EntityResource(instance['DBClusterIdentifier'],
                                           local_region,
-                                          instance['InstanceCreateTime'],
+                                          instance['ClusterCreateTime'],
                                           d_tags)
-                db_entities.append(resource)
+                db_cluster_entities.append(resource)
 
-        return db_entities
+        return db_cluster_entities
 
-    def get_all_instances(self, rds_client):
+    def get_all_clusters(self, rds_client):
         """
-        Get all RDS instances within region for given boto3 client
+        Get all RDS clusters within region for given boto3 client
         :param rds_client: boto3 rds service
         :return: all RDS instances within region for given boto3 client
         """
         # list of resource models
-        db_instances = []
+        db_clusters = []
         # temporary list of api models, as calls are batched
-        temp_instances = rds_client.describe_db_instances()
-        db_instances.extend(temp_instances['DBInstances'])
+        temp_clusters = rds_client.describe_db_clusters()
+        db_clusters.extend(temp_clusters['DBClusters'])
         # collect database instances
-        while 'Marker' in temp_instances:
-            temp_instances = rds_client.describe_db_instances(Marker=temp_instances['Marker'])
-            db_instances.extend(temp_instances['DBInstances'])
+        while 'Marker' in temp_clusters:
+            temp_clusters = rds_client.describe_db_clusters(Marker=temp_clusters['Marker'])
+            db_clusters.extend(temp_clusters['DBClusters'])
 
-        return db_instances
+        return db_clusters
 
     def get_shelvery_backups_only(self, all_snapshots, backup_tag_prefix, rds_client):
         """
@@ -178,11 +175,11 @@ class ShelveryRDSBackup(ShelveryEngine):
         all_backups = []
         marker_tag = f"{backup_tag_prefix}:{BackupResource.BACKUP_MARKER_TAG}"
         for snap in all_snapshots:
-            tags = rds_client.list_tags_for_resource(ResourceName=snap['DBSnapshotArn'])['TagList']
-            self.logger.info(f"Checking RDS Snap {snap['DBSnapshotIdentifier']}")
+            tags = rds_client.list_tags_for_resource(ResourceName=snap['DBClusterSnapshotArn'])['TagList']
+            self.logger.info(f"Checking RDS Snap {snap['DBClusterSnapshotIdentifier']}")
             d_tags = dict(map(lambda t: (t['Key'], t['Value']), tags))
             if marker_tag in d_tags:
-                backup_resource = BackupResource.construct(backup_tag_prefix, snap['DBSnapshotIdentifier'], d_tags)
+                backup_resource = BackupResource.construct(backup_tag_prefix, snap['DBClusterSnapshotIdentifier'], d_tags)
                 backup_resource.entity_resource = snap['EntityResource']
                 backup_resource.entity_id = snap['EntityResource'].resource_id
 
@@ -196,42 +193,42 @@ class ShelveryRDSBackup(ShelveryEngine):
         :return: All snapshots within region for rds_client
         """
         all_snapshots = []
-        tmp_snapshots = rds_client.describe_db_snapshots(SnapshotType='manual')
-        all_snapshots.extend(tmp_snapshots['DBSnapshots'])
+        tmp_snapshots = rds_client.describe_db_cluster_snapshots(SnapshotType='manual')
+        all_snapshots.extend(tmp_snapshots['DBClusterSnapshots'])
         while 'Marker' in tmp_snapshots:
-            tmp_snapshots = rds_client.describe_db_snapshots()
-            all_snapshots.extend(tmp_snapshots['DBSnapshots'])
+            tmp_snapshots = rds_client.describe_db_cluster_snapshots()
+            all_snapshots.extend(tmp_snapshots['DBClusterSnapshots'])
 
         self.populate_snap_entity_resource(all_snapshots)
 
         return all_snapshots
 
     def populate_snap_entity_resource(self, all_snapshots):
-        instance_ids = []
+        cluster_ids = []
         for snap in all_snapshots:
-            if snap['DBInstanceIdentifier'] not in instance_ids:
-                instance_ids.append(snap['DBInstanceIdentifier'])
+            if snap['DBClusterIdentifier'] not in cluster_ids:
+                cluster_ids.append(snap['DBClusterIdentifier'])
         entities = {}
         rds_client = boto3.client('rds')
         local_region = boto3.session.Session().region_name
 
-        for instance_id in instance_ids:
+        for cluster_id in cluster_ids:
             try:
-                rds_instance = rds_client.describe_db_instances(DBInstanceIdentifier=instance_id)['DBInstances'][0]
-                tags = rds_client.list_tags_for_resource(ResourceName=rds_instance['DBInstanceArn'])['TagList']
+                rds_instance = rds_client.describe_db_clusters(DBClusterIdentifier=cluster_id)['DBClusters'][0]
+                tags = rds_client.list_tags_for_resource(ResourceName=rds_instance['DBClusterArn'])['TagList']
                 d_tags = dict(map(lambda t: (t['Key'], t['Value']), tags))
-                rds_entity = EntityResource(instance_id,
+                rds_entity = EntityResource(cluster_id,
                                             local_region,
-                                            rds_instance['InstanceCreateTime'],
+                                            rds_instance['ClusterCreateTime'],
                                             d_tags)
-                entities[instance_id] = rds_entity
+                entities[cluster_id] = rds_entity
             except ClientError as e:
-                if 'DBInstanceNotFoundFault' in str(type(e)):
-                    entities[instance_id] = EntityResource.empty()
-                    entities[instance_id].resource_id = instance_id
+                if 'DBClusterNotFoundFault' in str(type(e)):
+                    entities[cluster_id] = EntityResource.empty()
+                    entities[cluster_id].resource_id = cluster_id
                 else:
                     raise e
 
         for snap in all_snapshots:
-            if snap['DBInstanceIdentifier'] in entities:
-                snap['EntityResource'] = entities[snap['DBInstanceIdentifier']]
+            if snap['DBClusterIdentifier'] in entities:
+                snap['EntityResource'] = entities[snap['DBClusterIdentifier']]

--- a/shelvery_cli/__main__.py
+++ b/shelvery_cli/__main__.py
@@ -7,7 +7,7 @@ import sys
 def setup_logging():
     root = logging.getLogger()
     root.setLevel(logging.DEBUG)
-    
+
     ch = logging.StreamHandler(sys.stdout)
     ch.setLevel(logging.DEBUG)
     formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
@@ -17,15 +17,15 @@ def setup_logging():
 
 def main(args=None):
     """The main routine."""
-    
+
     print(f"Shelvery v{shelvery.__version__}")
-    
+
     if args is None:
         args = sys.argv[1:]
     if len(args) < 2:
-        print("Usage: shelvery <backup_type> <action>\n\nBackup types: rds ebs\nActions: create_backups clean_backups")
+        print("Usage: shelvery <backup_type> <action>\n\nBackup types: rds ebs rds_cluster\nActions: create_backups clean_backups")
         exit(-2)
-    
+
     setup_logging()
     main_runner = ShelveryCliMain()
     main_runner.main(args[0], args[1])


### PR DESCRIPTION
### RDS Cluster snapshots support

Use `rds_cluster` as backup type. Everything else that applies for RDS Instance snapshots applies for RDS Cluster snapshots. Any cluster instances are skipped for backup in `rds` backup type, as they are backed up as cluster backup using `rds_cluster` backup type. 