### PR TITLE
v0.3.2 | Better error handling. Legacy datetime format allowed

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -2,3 +2,4 @@ v0.1.0, 6/11/2017 -- Initial release.
 v0.2.0, 14/11/2017 -- Control behaviour via resource tags. Multiple levels of configuration. RDS Cleanup.
 v0.3.0, 20/12/2017 -- RDS Cluster backups added
 v0.3.1, 12/02/2018 -- Fixed bug related to cleanup of yearly backups
+v0.3.2, 12/02/2018 -- Added error handling of cleanup on per-backup basis. Allowing legacy datetime format in backup tags

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup
 
-setup(name='shelvery', version='0.3.1', author='Base2Services R&D',
+setup(name='shelvery', version='0.3.2', author='Base2Services R&D',
       author_email='itsupport@base2services.com',
       url='http://github.com/base2Services/shelvery',
       classifiers=[

--- a/shelvery/backup_resource.py
+++ b/shelvery/backup_resource.py
@@ -13,6 +13,7 @@ class BackupResource:
     
     BACKUP_MARKER_TAG = 'backup'
     TIMESTAMP_FORMAT = '%Y-%m-%d-%H%M'
+    TIMESTAMP_FORMAT_LEGACY = '%Y%m%d-%H%M'
     
     RETENTION_DAILY = 'daily'
     RETENTION_WEEKLY = 'weekly'
@@ -78,7 +79,15 @@ class BackupResource:
         # read properties from tags
         obj.retention_type = tags[f"{tag_prefix}:retention_type"]
         obj.name = tags[f"{tag_prefix}:name"]
-        obj.date_created = datetime.strptime(tags[f"{tag_prefix}:date_created"], cls.TIMESTAMP_FORMAT)
+        try:
+            obj.date_created = datetime.strptime(tags[f"{tag_prefix}:date_created"], cls.TIMESTAMP_FORMAT)
+        except Exception as e:
+            if 'does not match format' in str(e):
+                str_date = tags[f"{tag_prefix}:date_created"]
+                print(f"Failed to read {str_date} as date, trying legacy format {cls.TIMESTAMP_FORMAT_LEGACY}")
+                obj.date_created = datetime.strptime(tags[f"{tag_prefix}:date_created"], cls.TIMESTAMP_FORMAT_LEGACY)
+                
+                
         obj.region = tags[f"{tag_prefix}:region"]
         return obj
     

--- a/shelvery/engine.py
+++ b/shelvery/engine.py
@@ -95,13 +95,17 @@ class ShelveryEngine:
         # check backups for expire date, delete if necessary
         for backup in existing_backups:
             self.logger.info(f"Checking backup {backup.backup_id}")
-            if backup.is_stale(self):
-                self.logger.info(
-                    f"{backup.retention_type} backup {backup.name} has expired on {backup.expire_date}, cleaning up")
-                self.delete_backup(backup)
-            else:
-                self.logger.info(f"{backup.retention_type} backup {backup.name} is valid "
-                                 f"until {backup.expire_date}, keeping this backup")
+            try:
+                if backup.is_stale(self):
+                    self.logger.info(
+                        f"{backup.retention_type} backup {backup.name} has expired on {backup.expire_date}, cleaning up")
+                    self.delete_backup(backup)
+                else:
+                    self.logger.info(f"{backup.retention_type} backup {backup.name} is valid "
+                                     f"until {backup.expire_date}, keeping this backup")
+            except Exception as ex:
+                # TODO notify via SNS
+                self.logger.error(f"Error checking backup {backup.backup_id} for cleanup: {ex}")
 
     def do_wait_backup_available(self, backup_region: str, backup_id: str, timeout_fn=None):
         """Wait for backup to become available. Additionally pass on timeout function


### PR DESCRIPTION
** v0.3.2 **

Error handling for cleanup is on per-backup basis, so corrupt backup does not mean broken cleanup process. Additionally, legacy date format used in initial version is supported for cleanup now - `%Y%m%d-%H%M`
